### PR TITLE
feat(review): auto-detect and start dev server on merge request reviews

### DIFF
--- a/dot_agents/skills/review/SKILL.md
+++ b/dot_agents/skills/review/SKILL.md
@@ -153,11 +153,13 @@ After merging specialist findings, add these directly:
 
 1. **Missing acceptance criteria** — if no linked issue with acceptance criteria was found, add a suggestion: "No linked issue with acceptance criteria found — cannot fully verify feature completeness."
 
-2. **Runtime verification** — if the diff modifies views, templates, controllers, frontend code, or UI interactions, run QA automatically:
-   1. Ensure the code under review is checked out (PR: already done; branch: `git checkout $BRANCH_NAME`; staged/uncommitted: skip)
-    2. Use the `qa` capability — pass context about which flows changed
-   3. Restore original branch if needed: `git checkout $ORIGINAL_BRANCH`
-   4. If QA cannot run (no server, no browser available), note "QA skipped — no running app detected" instead
-   5. Include results under `## QA Results` in the output
+2. **Runtime verification**:
+   - **Merge request reviews**: always run QA — the server was started during checkout (see `pr-workflow.md`). If server auto-start was skipped, note "QA skipped — could not detect dev server command" instead.
+   - **Branch / staged / commit reviews**: run QA only if the diff modifies views, templates, controllers, frontend code, or UI interactions. Ensure the code is checked out, then start the server using the same auto-detect logic in `pr-workflow.md`. If no server can be detected or started, note "QA skipped — no running app detected" instead.
+
+   Steps:
+   1. Use the `qa` capability — pass context about which flows changed and the local URL from the background server session
+   2. Restore original branch if needed and kill the background server session
+   3. Include results under `## QA Results` in the output
 
 Read `~/.agents/skills/review/output-format.md` and format the final output.

--- a/dot_agents/skills/review/pr-workflow.md
+++ b/dot_agents/skills/review/pr-workflow.md
@@ -21,6 +21,22 @@ If the capability cannot check out the branch locally (e.g., the repo isn't avai
 
 ---
 
+## Server Startup
+
+**After checking out the branch**, auto-detect and start the dev server using your `pty` capability:
+
+1. Inspect the repo root for a dev server command in this priority order:
+   - `package.json` → `scripts.dev`, then `scripts.start`
+   - `Procfile` → the `web:` entry
+   - `Makefile` → a `dev`, `serve`, or `start` target
+   - `README.md` → look for a "Getting started" / "Running locally" code block
+2. If a command is found, spawn the server in the background via your `pty` capability. Wait up to 15 seconds for the server to be ready (look for a "listening on" / "ready" / port-bound log line).
+3. Record the session ID and the local URL (e.g. `http://localhost:3000`) for use in QA.
+4. If no command can be determined, note "Server auto-start skipped — could not detect dev server command" and continue with review (QA will be skipped).
+5. After the full review is complete and QA has run, kill the PTY session and restore the original branch.
+
+---
+
 ## Prior Review History
 
 Fetch prior review history before dispatching specialists using your `code-review` capability:


### PR DESCRIPTION
Adds automatic dev server startup to the review skill's merge request workflow. After checking out the branch, the agent now auto-detects the dev server command (from `package.json`, `Procfile`, `Makefile`, or `README.md`), spawns it in the background, and always runs QA — rather than skipping when no server is detected.

Also includes earlier commits: capability manifest notes field, stripped thin integration skills, gws docs capability, and review specialist verification improvements.