### PR TITLE
feat(kb-enrich): pluggable collector architecture

### DIFF
--- a/dot_config/kb/collectors/gh.md
+++ b/dot_config/kb/collectors/gh.md
@@ -1,0 +1,46 @@
+---
+name: gh
+description: GitHub PRs, reviews, and issues
+---
+
+## Query recipe
+
+### Discover orgs
+
+Read GitHub orgs from chezmoi data:
+
+```
+chezmoi data --format json | jq -r '[.orgs | keys[]] | join(" ")'
+```
+
+If the result is empty, run without an org filter.
+
+### Fetch activity
+
+Use the `gh` skill to find the user's PRs and code reviews in the enrichment window:
+- PRs authored by the authenticated user
+- PRs where the user left a review
+
+Use the `gh` skill to find issues opened or updated by the user in the window.
+
+### Bot filter
+
+Skip any actor matching `dependabot[bot]`. The real GitHub actor login includes the brackets — match `dependabot[bot]`, not plain `dependabot`.
+
+## Triage rules
+
+Skip:
+- Automated dependency-bump PRs from `dependabot[bot]`
+- Activity in archived repositories
+
+Extract:
+- PRs merged or closed during the window (title, repo, link)
+- Review comments that capture decisions or design choices
+- Issues closed or opened that represent significant project work
+- Open review threads with outstanding action items assigned to the user
+
+## Extraction rules
+
+- For merged PRs, add a Status bullet to the relevant project profile if the work is significant; the write step handles repo-to-project mapping.
+- For review decisions, anchor to the product/project and note the PR URL.
+- For action items from open review threads, note the PR URL and thread for cross-reference at write time.

--- a/dot_config/kb/collectors/linear.md
+++ b/dot_config/kb/collectors/linear.md
@@ -1,0 +1,23 @@
+---
+name: linear
+description: Linear issues and comments
+---
+
+Use the `linear` skill to fetch issues updated within the enrichment window where the authenticated user is the assignee, creator, or a comment author. Also fetch comments on those issues to surface inline decisions and action items.
+
+## Triage rules
+
+Skip:
+- Issues outside projects or teams the user is active on
+
+Extract:
+- Tickets completed (state moved to Done or Cancelled) during the window
+- Decisions captured in comments (architectural choices, scope changes, explicit "we decided" statements)
+- Action items assigned to the user that remain open at window end
+- Project or product status updates
+
+## Extraction rules
+
+- Anchor decisions to the product or project the Linear issue belongs to.
+- For completed tickets, record the title and link as a Status bullet in the relevant project profile if the work is significant.
+- For action items, note the Linear issue URL so the item can be cross-referenced at write time.

--- a/dot_config/kb/collectors/opencode.md
+++ b/dot_config/kb/collectors/opencode.md
@@ -1,0 +1,33 @@
+---
+name: opencode
+description: OpenSpec durable store and OpenCode sessions — authoritative source for /implement work and all coding activity
+---
+
+## Phase 1 — Read the OpenSpec durable store
+
+For each date in the enrichment window:
+
+1. **Collect excluded worktrees.** Glob `~/.local/share/kb/openspec/*/changes/archive/YYYY-MM-DD-*/kb-meta.yaml` for each date in the window. Each file contains a `worktree:` field (the absolute repo/worktree root, stamped at archive time). Collect all `worktree:` values across the window into the session exclusion set.
+
+2. **Read design artifacts.** For each matching archive directory, read `design.md` for decisions, the "why", and rejected alternatives.
+
+3. **Read standing specs.** For each repo store, read `~/.local/share/kb/openspec/<repo-slug>/specs/` for the standing requirements that were active during the enrichment window.
+
+## Phase 2 — Get OpenCode sessions
+
+Use the **`opencode` skill** to query sessions whose `time_updated` falls in the enrichment window. Skip any session whose `directory` appears in the exclusion set — those sessions are covered by the durable change artifacts from Phase 1. Read transcripts only for non-excluded sessions.
+
+**Benign failure modes:** a missed match (stale or absent `kb-meta.yaml`) wastes one transcript read; an over-match (a session in an excluded worktree that wasn't actually part of the archived change) relies on the better, distilled artifact rather than the raw transcript. Neither loses correctness.
+
+## Extraction rules
+
+From the OpenSpec durable store:
+- Key decisions and rejected alternatives from each `design.md` — these are the authoritative source of truth for `/implement` reasoning; use them rather than reconstructing from transcripts.
+- Standing requirements from each `specs/` directory.
+- These artifacts are already in the kb via symlink; reference them, don't copy them.
+
+From non-excluded OpenCode sessions:
+- Coding activity per project (session count and diff-stats, for the journal)
+- People facts (new contacts, role changes, team membership)
+- Informal decisions made outside the openspec workflow
+- Action items

--- a/dot_config/kb/collectors/slack.md
+++ b/dot_config/kb/collectors/slack.md
@@ -1,0 +1,24 @@
+---
+name: slack
+description: Slack messages and threads
+---
+
+Use the `slack` skill to find messages sent by the authenticated user in the enrichment window. Fetch threads for any message that received replies.
+
+## Triage rules
+
+Skip:
+- Automated bot messages and notification-only posts
+- Threads where the user was only mentioned but did not participate
+
+Extract:
+- Informal decisions made in chat (look for phrases like "let's go with", "we decided", "agreed")
+- Action items directed at or taken on by the user
+- New contact information (email addresses, GitHub handles, role or team changes mentioned in conversation)
+- Project or product status updates not captured elsewhere
+
+## Extraction rules
+
+- Anchor decisions to the project or product they concern.
+- For action items, note the thread URL so the item can be cross-referenced at write time.
+- For contact info updates, note the source channel and date so the person profile update can cite it.

--- a/dot_config/kb/collectors/zoom.md
+++ b/dot_config/kb/collectors/zoom.md
@@ -1,0 +1,32 @@
+---
+name: zoom
+description: Zoom meeting transcripts — distilled via kb-distill on-device model
+---
+
+Use the `zoom` skill to locate caption files for meetings whose date prefix falls within the enrichment window. For each in-window meeting, run the distillation step below.
+
+## Distillation step
+
+For each in-window transcript, run:
+
+```
+~/.config/opencode/bin/kb-distill <caption-file> "<title>" YYYY-MM-DD
+```
+
+Use the returned JSON facts (fields: `participants`, `topics`, `decisions`, `action_items`, `open_questions`, `summary`) in place of the raw caption text when extracting people facts, decisions, and action items. Only the on-device local model sees the raw transcript.
+
+If `kb-distill` exits non-zero, read the raw transcript yourself instead and note the fallback in the journal.
+
+## Triage rules
+
+Extract from the distilled JSON:
+- Meeting participants and any contact info surfaced (new names, roles, team membership)
+- Decisions recorded under the `decisions` field
+- Action items from the `action_items` field
+- Open questions from `open_questions` that remain unresolved at the end of the enrichment window
+
+## Extraction rules
+
+- Map participants to people facts.
+- Anchor decisions to the project or product they concern.
+- For action items, note the meeting title and date so the item can be cross-referenced at write time.

--- a/dot_config/opencode/commands/kb-enrich.md
+++ b/dot_config/opencode/commands/kb-enrich.md
@@ -1,50 +1,38 @@
 ---
-description: Daily knowledge base enrichment — enrich profiles, journal, and decisions for each date since the last run
+description: Knowledge base enrichment — enrich profiles, journal, and decisions for each date since the last run
 subtask: true
 ---
 
-Run the daily knowledge base enrichment. By default enrich every date since the last run (see **Date range** below), not just today; honor an explicit date or range given in arguments instead.
+Enrich the knowledge base for every date since the last run. An explicit date or range given in arguments overrides.
 
 $ARGUMENTS
 
-## Sources
+## Step 1 — Resolve date range
 
-Check activity across all available sources:
+The most recent `~/.local/share/kb/journal/YYYY-MM-DD.md` is the last-run marker: enrich each date from (last journal date + 1) through today, inclusive. This makes a Monday run sweep the trailing weekend and lets a skipped run self-heal on the next run. If no prior journal exists, default to today. An explicit date or range in arguments overrides this.
 
-- **opencode** coding sessions
-- **slack** chat messages and threads
-- **zoom** meeting transcripts — captions live at `~/Documents/Zoom/YYYY-MM-DD HH.MM.SS <Title>/meeting_saved_closed_caption.txt`. For each transcript whose dir-date falls in the enrich window, distill it with the local on-device model first (see Extract step) instead of reading the full raw caption text.
-- **linear** issues and comments
-- **gh** code reviews, PRs, and issues
-- **openspec durable store (AUTHORITATIVE for `/implement` work)** — each worktree's `openspec/` carries two narrow symlinks into a durable per-repo store at `~/.local/share/kb/openspec/<repo-slug>/` (`openspec/specs` → store `specs/`, `openspec/changes/archive` → store `changes/archive/`). At Ship, `openspec archive` moves a completed change through the `changes/archive` symlink into the store, so its artifacts persist regardless of when work shipped. For each date being enriched, read `~/.local/share/kb/openspec/*/changes/archive/<date>-*/design.md` for decisions, the "why", and rejected alternatives, and read each store's durable `specs/` for the standing requirements. These structured artifacts are the source of truth for the reasoning behind completed `/implement` work — use them instead of reconstructing it from full (token-expensive, lossy) session transcripts.
+## Step 2 — Load collectors
 
-### Session exclusion — the core token-saving dedup
+Collectors live at `~/.config/kb/collectors/*.md`. Which collectors run is determined by the enabled list in chezmoi local config:
 
-The openspec store is authoritative for `/implement` work, so the sessions that PRODUCED an archived change must be EXCLUDED from transcript reads. Build the exclusion set and skip those sessions:
+```
+chezmoi data --format json | jq -r '.kb.collectors[]'
+```
 
-1. **Collect excluded worktrees.** For each date being enriched, read every `~/.local/share/kb/openspec/*/changes/archive/<date>-*/kb-meta.yaml` and collect its `worktree:` value (the absolute repo/worktree root, stamped at archive). That set is the exclusion list.
-2. **Skip those sessions.** When scanning **opencode** sessions, a session is identified by its `directory` column in the `session` table of `~/.local/share/opencode/opencode.db`. SKIP any session whose `directory` is in the exclusion set — for those, narrate from the change's `design.md`/specs, not the transcript. Only sessions NOT covered by an archived change get a transcript read.
-3. **Filter at query time.** Pass the collected worktrees as the `NOT IN (...)` list and bound by the date window (`time_updated` is epoch-ms):
+Run only the listed collectors. If the key is absent, log "kb.collectors not configured" and stop.
 
-   ```sql
-   SELECT id, directory, title, time_updated
-   FROM session
-   WHERE time_updated BETWEEN :start_ms AND :end_ms
-     AND directory NOT IN ('/abs/worktree/a', '/abs/worktree/b');
-   -- returned sessions are the ONLY ones that need a transcript read;
-   -- excluded directories are covered by the durable change artifacts instead.
-   ```
+## Step 3 — Run each collector
 
-**Benign failure modes** (neither loses correctness): a missed match (stale/absent `kb-meta.yaml`) just wastes one transcript read; an over-match (a session in an excluded worktree that wasn't really part of the change) just relies on the better, distilled artifact instead of the transcript.
+For each enabled collector, apply its embedded query recipe and triage/extraction rules against the resolved date window. Collectors are independent — run them in any order. The opencode collector handles its own internal openspec→exclusion→sessions sequencing.
 
-## Enrichment Steps
+## Step 4 — Write outputs
 
-1. **Extract** people facts, project updates, and decisions from each source.
-   - **Zoom transcripts:** for each in-window transcript, run `~/.config/opencode/bin/kb-distill <caption-file> "<title>" <date>` and use the returned JSON facts (participants, topics, decisions, action_items, open_questions, summary) in place of the raw caption text when extracting people facts, decisions, and action items. The raw transcript is sent only to the on-device local model (privacy positive); the authoritative do-not-store privacy filter below still applies at the WRITE step. **If `kb-distill` exits non-zero, read the raw transcript yourself instead and note the fallback in the journal.**
-2. **Journal** — write one cross-project rollup journal file per enriched date, each with diff stats. By construction each is THIN: feed it only from the NON-excluded sessions (those not covered by an archived change) plus git diff-stats. For `/implement` work, do NOT re-narrate the openspec change — reference the durable store artifacts (`design.md`/specs already in the kb via the symlink). The journal's role is the cross-project rollup + non-`/implement` activity, not a reconstruction of openspec work. Keep it; just don't duplicate the store.
-3. **Profiles** — merge new facts into knowledge-base people and project profiles
-4. **Decisions** — add any decisions to the decisions log. Pull key design decisions and rejected alternatives from the durable store's `~/.local/share/kb/openspec/*/changes/archive/<date>-*/design.md` (READ, don't copy — the artifacts are already in the kb). The decisions log is a distilled record anchored to its product/project, not a dump of the design files.
-5. **Action items** — extract action items from the enriched window's activity. Cross-reference within the same activity data — if the activity shows you already took the action (replied to the thread, reviewed the PR, closed the issue), skip the reminder. Only create reminders for items that were not resolved within the enriched window.
+After all collectors have run, write the enrichment outputs:
+
+1. **Journal** — write one cross-project rollup journal file per enriched date at `~/.local/share/kb/journal/YYYY-MM-DD.md`, each with diff stats. By construction each is THIN: feed it only from the NON-excluded sessions (those not covered by an archived change) plus git diff-stats. For `/implement` work, do NOT re-narrate the openspec change — reference the durable store artifacts (`design.md`/specs already in the kb via the symlink). The journal's role is the cross-project rollup + non-`/implement` activity, not a reconstruction of openspec work.
+2. **Profiles** — merge new facts into knowledge-base people and project profiles at `~/.local/share/kb/people/` and `~/.local/share/kb/projects/`.
+3. **Decisions** — add any decisions to the decisions log. Pull key design decisions and rejected alternatives from the durable store's `~/.local/share/kb/openspec/*/changes/archive/YYYY-MM-DD-*/design.md` (READ, don't copy — the artifacts are already in the kb via the symlink). The decisions log is a distilled record anchored to its product/project, not a dump of the design files.
+4. **Action items** — extract action items from the enriched window's activity. Cross-reference within the same activity data — if the activity shows you already took the action (replied to the thread, reviewed the PR, closed the issue), skip the reminder. Only create reminders for items that were not resolved within the enriched window.
 
 ## Privacy
 
@@ -54,7 +42,3 @@ Do not extract or store:
 - Performance evaluations
 - Legal or attorney-client privileged content
 - Content from HR-related discussions
-
-## Date range
-
-Enrich the gap since the last run, not a hard single day. The most recent `~/.local/share/kb/journal/YYYY-MM-DD.md` is the last-run marker: enrich each date from (last journal date + 1) through today, inclusive. This makes a Monday run sweep the trailing weekend and lets a skipped run self-heal on the next run. If no prior journal exists, default to today. An explicit date or range in arguments overrides this.

--- a/local.yaml.example
+++ b/local.yaml.example
@@ -22,6 +22,12 @@ prod_services:
   your-api-service: your-api-repo
   your-worker-service: your-worker-repo
 
+# Knowledge-base collectors to run during /kb-enrich. Each name maps to a recipe
+# file at ~/.config/kb/collectors/<name>.md. Only listed collectors run; omit one
+# to disable it without deleting its recipe.
+kb:
+  collectors: [opencode, slack, zoom, linear, gh]
+
 # Secrets manifest — each entry declares a name. Values are stored in the macOS
 # Keychain under service "chezmoi" with account = the name. Populate them via:
 #   security add-generic-password -U -s "chezmoi" -a "<name>" -w "<value>"


### PR DESCRIPTION
Splits `/kb-enrich` into a thin orchestrator plus per-source collector recipes at `~/.config/kb/collectors/`. Collectors are thin "what to extract" recipes that defer fetch mechanics to each source's skill; the orchestrator owns the date window, the enabled-collector list (from chezmoi local config), privacy, and the write step. The `opencode` collector folds in the OpenSpec durable store and builds its session-exclusion set internally.

Iterates the idea from #31 forward from `main`; that PR stays open pending the author's input.