### PR TITLE
refactor(learn): narrow /learn to AGENTS.md, defer situational knowledge to cq

### DIFF
--- a/dot_config/opencode/commands/learn.md
+++ b/dot_config/opencode/commands/learn.md
@@ -1,17 +1,14 @@
 ---
-description: Capture non-obvious discoveries from this session into AGENTS.md or a new skill
+description: Capture non-obvious discoveries from this session into AGENTS.md
 ---
 
 ## What to Capture
 
-Analyze the session for non-obvious learnings only:
+Analyze the session for non-obvious learnings that agents need **proactively on every session**, regardless of task: safety rules, workflow constraints, always-applicable gotchas.
 
 - Hidden relationships between files or modules
 - Execution paths that differ from how code appears
 - Non-obvious configuration, env vars, or flags
-- Debugging breakthroughs when error messages were misleading
-- API/tool quirks and workarounds
-- Build/test commands not in README
 - Architectural decisions and constraints
 - Files that must change together
 
@@ -22,36 +19,17 @@ Analyze the session for non-obvious learnings only:
 - Things already in an AGENTS.md
 - Verbose explanations
 - Session-specific details (timestamps, branch names, etc.)
+- Situational/reactive knowledge — debugging breakthroughs, API/tool quirks and workarounds, fix recipes for recurring issues, troubleshooting procedures. That's `cq`'s job, not this command's: `cq propose` it in the moment, or run `/cq:reflect` at session end to catch anything missed. `cq` is query-on-demand and can't load anything proactively, which is why AGENTS.md still needs this command for the always-loaded half.
 
 ## Where to Place Learnings
 
-Two equally valid destinations -- choose based on when the knowledge is needed:
-
-### AGENTS.md
-
-Use for learnings that agents need **proactively on every session**: safety rules, workflow constraints, always-applicable gotchas. AGENTS.md files can exist at any directory level and are automatically loaded when an agent reads files in that tree.
+AGENTS.md files can exist at any directory level and are automatically loaded when an agent reads files in that tree.
 
 - Project-wide: root `AGENTS.md`
 - Package/module-specific: `packages/foo/AGENTS.md`
 - Feature-specific: `src/auth/AGENTS.md`
 
 The global `~/.config/opencode/AGENTS.md` is chezmoi-managed — edit it at `$(chezmoi source-path)/dot_config/opencode/AGENTS.md`.
-
-### Skills
-
-Use for learnings that are **reactive/situational** -- only needed when a specific problem arises or task is requested. This includes: troubleshooting procedures, specialized workflows, fix recipes for recurring issues, tool-specific gotchas.
-
-**Prefer updating an existing skill over creating a new one.** Check existing skills first -- the learning often belongs as a new section, example, or failure mode in a skill that already exists. Create a new skill only when no existing skill covers the domain.
-
-**Project-local skills** live in `.agents/skills/` in the current repo. Use for learnings specific to one project.
-
-**Global skills** live in `$(chezmoi source-path)/skills/` (chezmoi-managed, deployed to `~/.agents/skills/`). Run `chezmoi apply` to deploy.
-
-New skills need a `<name>/SKILL.md` with `name:` and `description:` frontmatter. The description is the trigger -- make it specific enough for the agent to know when to load it.
-
-### Decision rule
-
-If the knowledge is needed every session regardless of task, use AGENTS.md. If you'd only reach for it when something specific goes wrong or is asked, use a skill.
 
 ## Input
 
@@ -71,15 +49,12 @@ Every line you add should clear this bar: **does the agent genuinely not know th
 
 Target: >70% Expert content. If most lines are Activation or Redundant, the learning isn't worth capturing.
 
-**The description is the trigger.** For new skills, the description is the only thing the agent sees before deciding whether to load it. A vague description means the skill never activates. Make it specific: what situation, what problem, what the agent gains.
-
 ## Process
 
-1. Review session for discoveries, errors that took multiple attempts, unexpected connections
-2. For each learning, decide: AGENTS.md or skill?
-3. Read existing files at the target location (AGENTS.md at relevant directory level, or existing skill)
-4. Update the existing file, or create a new one if nothing fits
-5. Apply the quality gate — strip Redundant content, keep Expert tight
-6. Keep entries to 1-3 lines per insight
+1. Review session for discoveries that belong in every future session's context, not something situational `cq` should hold instead
+2. Read the existing AGENTS.md at the relevant directory level
+3. Update it, or create a new one if nothing fits
+4. Apply the quality gate — strip Redundant content, keep Expert tight
+5. Keep entries to 1-3 lines per insight
 
-After updating, summarize which files were created/updated and how many learnings per file.
+After updating, summarize which AGENTS.md files were created/updated and how many learnings per file.

--- a/local.yaml.example
+++ b/local.yaml.example
@@ -46,7 +46,7 @@ prod_services:
 # file at ~/.config/kb/collectors/<name>.md. Only listed collectors run; omit one
 # to disable it without deleting its recipe.
 kb:
-  collectors: [opencode, slack, zoom, linear, gh, atlassian]
+  collectors: [aoe, slack, zoom, linear, gh, atlassian]
   # Confluence page ID of the Decision Log container page (the page running the
   # Page Properties Report macro that auto-lists its children). Leave unset/empty
   # to skip Decision Log write-back in /kb-enrich entirely — no Confluence write


### PR DESCRIPTION
## Description

`/learn`'s skill-branch duplicated cq's own `/cq:reflect` end-of-session scan — both review a session for non-obvious discoveries and write them somewhere for future reuse. cq is query-on-demand (an agent has to call `query` mid-task) and can't load anything proactively, so `/learn` still earns its keep for the AGENTS.md half; the reactive/situational half (debugging breakthroughs, API/tool quirks, fix recipes, troubleshooting procedures) now goes through `cq propose` in the moment or `/cq:reflect` at session end instead of a hand-maintained `SKILL.md`.

## Changes

- `dot_config/opencode/commands/learn.md`: removed the "Skills" destination section and the AGENTS.md-vs-skill decision rule; description and process steps narrowed to AGENTS.md only; "Do NOT capture" list now explicitly routes situational/reactive knowledge to `cq propose`/`cq:reflect`.

Not in scope here: actually installing `cq` (`cq install --target opencode`) — this PR only updates the command doc for once it's installed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated learning guidance to focus on proactive, broadly applicable knowledge for `AGENTS.md`.
  * Clarified how to handle reactive troubleshooting discoveries.
  * Simplified review, quality, formatting, and reporting steps.
  * Updated the example knowledge-base configuration to use the `aoe` collector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->